### PR TITLE
move-queue-params-to-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine
 
 ENV MAX_MESSAGE_SIZE=8k
+ENV QUEUE_WORKER_THREADS=2
+ENV QUEUE_DEQUEUE_BATCH_SIZE=1000
+ENV QUEUE_SIZE=10000
 
 RUN apk add --no-cache rsyslog
 COPY ./rsyslog/rsyslogd.conf /etc/rsyslogd.conf

--- a/rsyslog/rsyslogd.conf
+++ b/rsyslog/rsyslogd.conf
@@ -11,9 +11,9 @@ template(name="raw" type="list") {
 
 ruleset(
     name="raw"
-    queue.workerthreads="2"
-    queue.dequeueBatchSize="1000"
-    queue.size="10000"
+    queue.workerthreads="${QUEUE_WORKER_THREADS}"
+    queue.dequeueBatchSize="${QUEUE_DEQUEUE_BATCH_SIZE}"
+    queue.size="${QUEUE_SIZE}"
 ){
     action(
         type="ompipe"


### PR DESCRIPTION
 Предлагаю сделать это конфигурируемым. Наш не справляется с дефолтными настройками
```E_WARNING: socket_sendto(): unable to write to socket [105]: No buffer space available```